### PR TITLE
Create clickable melody playground for Keyboard Kids

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,19 +3,23 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Classical Melody Keyboard</title>
+  <title>Keyboard Kids</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700&family=Nunito:wght@400;600;700&display=swap');
     :root {
       color-scheme: light;
-      --bg: #f3f1ff;
+      --bg: #fff6f0;
+      --bg-secondary: #fef3ff;
       --panel: #ffffff;
-      --text: #1d1b2f;
-      --accent-1: #ff9f1c;
-      --accent-2: #ff595e;
-      --accent-3: #8ac926;
-      --accent-4: #1982c4;
-      --accent-5: #6a4c93;
-      --accent-6: #ffca3a;
+      --text: #30263b;
+      --muted-text: rgba(48, 38, 59, 0.7);
+      --accent-1: #ff8ba0;
+      --accent-2: #ffa94d;
+      --accent-3: #7bdff2;
+      --accent-4: #9d6bff;
+      --accent-5: #ffd166;
+      --accent-6: #6ede8a;
+      --accent-7: #ffa3d7;
       --toast-accent: var(--accent-4);
     }
 
@@ -25,34 +29,75 @@
 
     body {
       margin: 0;
-      font-family: 'Nunito', 'Helvetica Neue', Arial, sans-serif;
-      background: radial-gradient(circle at top, #ffffff 0%, var(--bg) 60%, #e2ddff 100%);
+      font-family: 'Baloo 2', 'Nunito', 'Helvetica Neue', Arial, sans-serif;
+      background: radial-gradient(circle at top left, var(--bg) 0%, var(--bg-secondary) 45%, #ffeef5 100%);
       color: var(--text);
       min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
       padding: 2rem 1.5rem 3rem;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      border-radius: 50%;
+      filter: blur(0.5px);
+      opacity: 0.45;
+      z-index: 0;
+    }
+
+    body::before {
+      width: 420px;
+      height: 420px;
+      background: radial-gradient(circle, rgba(255, 195, 160, 0.55), rgba(255, 138, 160, 0));
+      top: -140px;
+      right: -120px;
+    }
+
+    body::after {
+      width: 520px;
+      height: 520px;
+      background: radial-gradient(circle, rgba(155, 107, 255, 0.4), rgba(123, 223, 242, 0));
+      bottom: -180px;
+      left: -160px;
     }
 
     main {
       max-width: 1040px;
       width: 100%;
       background: var(--panel);
-      border-radius: 24px;
-      box-shadow: 0 20px 60px rgba(40, 24, 80, 0.25);
-      padding: 2.5rem 2rem 2.75rem;
+      border-radius: 32px;
+      box-shadow: 0 24px 70px rgba(157, 107, 255, 0.2);
+      padding: 2.75rem 2.25rem 3rem;
       position: relative;
       overflow: hidden;
+      isolation: isolate;
     }
 
     main::after {
       content: "";
       position: absolute;
-      inset: -120px -160px auto auto;
-      width: 280px;
-      height: 280px;
-      background: linear-gradient(135deg, rgba(255, 153, 0, 0.4), rgba(25, 130, 196, 0.35));
+      inset: auto -140px -140px auto;
+      width: 360px;
+      height: 360px;
+      background: radial-gradient(circle at center, rgba(123, 223, 242, 0.55), rgba(255, 161, 77, 0.25));
+      border-radius: 50%;
+      z-index: 0;
+      filter: blur(0.5px);
+    }
+
+    main::before {
+      content: "";
+      position: absolute;
+      inset: -160px auto auto -120px;
+      width: 320px;
+      height: 320px;
+      background: radial-gradient(circle at top right, rgba(255, 138, 160, 0.55), rgba(255, 209, 102, 0.2));
       border-radius: 50%;
       z-index: 0;
       filter: blur(0.5px);
@@ -62,46 +107,66 @@
       position: relative;
       z-index: 1;
       text-align: center;
-      margin-bottom: 2.5rem;
+      margin-bottom: 2.75rem;
+    }
+
+    header::after {
+      content: "";
+      position: absolute;
+      inset: auto 50% -36px 50%;
+      transform: translateX(-50%);
+      width: min(320px, 70%);
+      height: 12px;
+      background: linear-gradient(90deg, rgba(255, 138, 160, 0.35), rgba(123, 223, 242, 0.6), rgba(255, 209, 102, 0.35));
+      border-radius: 999px;
+      opacity: 0.9;
     }
 
     h1 {
       margin: 0 0 0.75rem;
-      font-size: clamp(2.1rem, 4vw, 2.8rem);
+      font-size: clamp(2.4rem, 5.5vw, 3.4rem);
+      line-height: 1.05;
+      background: linear-gradient(120deg, var(--accent-4), var(--accent-1), var(--accent-2));
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      text-shadow: 0 8px 24px rgba(157, 107, 255, 0.3);
     }
 
     p.lead {
       margin: 0 auto;
       max-width: 640px;
       font-size: 1.1rem;
-      line-height: 1.6;
+      line-height: 1.65;
+      color: var(--muted-text);
     }
 
     .now-playing {
-      margin: 1.75rem auto 0;
-      max-width: 680px;
-      background: rgba(255, 255, 255, 0.75);
-      border-radius: 16px;
-      padding: 0.85rem 1.2rem;
+      margin: 1.9rem auto 0;
+      max-width: 720px;
+      background: rgba(255, 255, 255, 0.85);
+      border-radius: 22px;
+      padding: 0.95rem 1.4rem;
       display: flex;
       flex-wrap: wrap;
       justify-content: center;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.6rem;
       font-size: 1rem;
-      box-shadow: 0 8px 24px rgba(30, 30, 60, 0.12);
+      box-shadow: 0 12px 28px rgba(157, 107, 255, 0.18);
     }
 
     .now-playing .label {
       font-weight: 700;
       text-transform: uppercase;
-      letter-spacing: 0.08em;
-      font-size: 0.85rem;
-      color: rgba(29, 27, 47, 0.7);
+      letter-spacing: 0.1em;
+      font-size: 0.82rem;
+      color: rgba(48, 38, 59, 0.55);
     }
 
     .now-playing .value {
       font-weight: 600;
+      color: var(--text);
     }
 
     .keys-grid {
@@ -109,140 +174,130 @@
       z-index: 1;
       display: flex;
       flex-direction: column;
+      gap: 1.7rem;
+    }
+
+    .keys-grid {
+      position: relative;
+      z-index: 1;
+      margin-top: 3rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 1.5rem;
     }
 
-    .keys-row-wrapper {
+    .melody-card {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 255, 255, 0.78));
+      border-radius: 28px;
+      padding: 1.6rem 1.45rem 2.2rem;
       display: flex;
       flex-direction: column;
-      gap: 0.65rem;
+      text-align: left;
+      cursor: pointer;
+      box-shadow: 0 18px 38px rgba(48, 38, 59, 0.14);
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
+      border: 3px solid transparent;
+      position: relative;
+      overflow: hidden;
+      --card-color: var(--accent-4);
     }
 
-    .keys-row-label {
-      font-size: 0.8rem;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: rgba(29, 27, 47, 0.55);
-      padding-left: 0.35rem;
+    .melody-card::before {
+      content: "";
+      position: absolute;
+      inset: -20% auto auto -20%;
+      width: 200px;
+      height: 200px;
+      background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.65), transparent 72%);
+      opacity: 0;
+      transition: opacity 0.3s ease;
     }
 
-    .keys-row {
-      display: grid;
-      grid-auto-flow: column;
-      grid-auto-columns: minmax(115px, 1fr);
-      gap: 1rem;
-      padding-bottom: 0.4rem;
-      overflow-x: auto;
-      scroll-snap-type: x mandatory;
-    }
-
-    .keys-row::-webkit-scrollbar {
-      height: 8px;
-    }
-
-    .keys-row::-webkit-scrollbar-thumb {
-      background: rgba(106, 76, 147, 0.22);
-      border-radius: 999px;
-    }
-
-    .keys-row:focus-visible {
-      outline: 2px solid var(--accent-4);
+    .melody-card:focus-visible {
+      outline: 3px solid rgba(157, 107, 255, 0.6);
       outline-offset: 4px;
     }
 
-    .key-card {
-      background: rgba(255, 255, 255, 0.9);
-      border-radius: 18px;
-      padding: 1.4rem 1.1rem 2rem;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      cursor: pointer;
-      box-shadow: 0 10px 24px rgba(30, 30, 60, 0.18);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-      border: 3px solid transparent;
-      position: relative;
-      --card-color: var(--accent-4);
-      scroll-snap-align: start;
+    .melody-card .spot-icon {
+      font-size: 2.15rem;
+      filter: drop-shadow(0 6px 12px rgba(48, 38, 59, 0.18));
     }
 
-    .key-card span.letter {
-      font-size: clamp(2.1rem, 5vw, 3rem);
+    .melody-card .spot-name {
+      margin: 0.55rem 0 0.15rem;
+      font-size: 1.25rem;
       font-weight: 800;
-      letter-spacing: 0.05em;
-      margin-bottom: 0.55rem;
-      display: inline-flex;
-      flex-wrap: wrap;
-      width: 68px;
-      height: 68px;
-      border-radius: 18px;
-      align-items: center;
-      justify-content: center;
-      line-height: 1.1;
-      text-align: center;
-      white-space: normal;
-      color: white;
+      color: var(--text);
+      letter-spacing: 0.01em;
     }
 
-    .key-card span.title {
+    .melody-card .melody-title {
       font-size: 1rem;
-      font-weight: 600;
-      line-height: 1.4;
+      font-weight: 700;
+      color: rgba(48, 38, 59, 0.85);
+      margin: 0;
     }
 
-    .key-card span.subtitle {
-      display: block;
-      margin-top: 0.25rem;
+    .melody-card .melody-composer {
+      margin: 0.3rem 0 0;
+      font-size: 0.85rem;
+      color: rgba(48, 38, 59, 0.6);
+    }
+
+    .melody-card .spot-description {
+      margin-top: 0.85rem;
       font-size: 0.9rem;
-      opacity: 0.7;
+      line-height: 1.5;
+      color: rgba(48, 38, 59, 0.74);
     }
 
-    .key-card .progress-track {
+    .melody-card .progress-track {
       position: absolute;
       left: 18px;
       right: 18px;
-      bottom: 14px;
+      bottom: 16px;
       height: 8px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.7);
+      background: rgba(255, 255, 255, 0.78);
       overflow: hidden;
       opacity: 0;
-      transform: translateY(6px);
+      transform: translateY(8px);
       transition: opacity 0.3s ease, transform 0.3s ease;
     }
 
-    .key-card .progress-bar {
+    .melody-card .progress-bar {
       width: 0%;
       height: 100%;
       background: var(--card-color);
       border-radius: inherit;
     }
 
-    .key-card[data-active="true"] .progress-track {
+    .melody-card[data-active="true"] .progress-track {
       opacity: 1;
       transform: translateY(0);
     }
 
-    .key-card[data-active="true"] {
-      transform: translateY(-6px) scale(1.02);
-      box-shadow: 0 16px 32px rgba(30, 30, 60, 0.25);
-      border-color: rgba(106, 76, 147, 0.6);
+    .melody-card[data-active="true"] {
+      transform: translateY(-6px) scale(1.015);
+      box-shadow: 0 28px 52px rgba(157, 107, 255, 0.35);
+      border-color: rgba(157, 107, 255, 0.4);
     }
 
-    .key-card[data-queued="true"] {
-      border-color: rgba(106, 76, 147, 0.35);
-      box-shadow: 0 12px 26px rgba(30, 30, 60, 0.18);
+    .melody-card[data-active="true"]::before {
+      opacity: 1;
     }
 
-    .key-card[data-queued="true"]::after {
+    .melody-card[data-queued="true"] {
+      border-color: rgba(157, 107, 255, 0.28);
+      box-shadow: 0 20px 40px rgba(48, 38, 59, 0.16);
+    }
+
+    .melody-card[data-queued="true"]::after {
       content: 'Next';
       position: absolute;
-      top: 10px;
-      right: 10px;
-      background: rgba(106, 76, 147, 0.16);
+      top: 12px;
+      right: 12px;
+      background: rgba(157, 107, 255, 0.18);
       color: var(--text);
       font-size: 0.65rem;
       font-weight: 700;
@@ -252,12 +307,12 @@
       border-radius: 999px;
     }
 
-    .key-card:active {
+    .melody-card:active {
       transform: translateY(2px) scale(0.99);
     }
 
     .controls {
-      margin-top: 2.5rem;
+      margin-top: 2.7rem;
       position: relative;
       z-index: 1;
       display: flex;
@@ -265,10 +320,11 @@
       justify-content: space-between;
       align-items: center;
       gap: 1.5rem;
-      background: rgba(255, 255, 255, 0.8);
-      border-radius: 16px;
-      padding: 1.1rem 1.4rem;
-      box-shadow: 0 12px 26px rgba(30, 30, 60, 0.15);
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 24px;
+      padding: 1.3rem 1.6rem;
+      box-shadow: 0 16px 34px rgba(48, 38, 59, 0.16);
+      border: 2px solid rgba(157, 107, 255, 0.12);
     }
 
     .volume-control {
@@ -283,17 +339,17 @@
       font-weight: 700;
       letter-spacing: 0.05em;
       text-transform: uppercase;
-      font-size: 0.75rem;
-      color: rgba(29, 27, 47, 0.65);
+      font-size: 0.78rem;
+      color: rgba(48, 38, 59, 0.6);
     }
 
     .volume-control input[type="range"] {
       -webkit-appearance: none;
       appearance: none;
       width: clamp(160px, 25vw, 260px);
-      height: 6px;
+      height: 8px;
       border-radius: 999px;
-      background: rgba(106, 76, 147, 0.24);
+      background: rgba(157, 107, 255, 0.25);
       outline: none;
       position: relative;
     }
@@ -301,21 +357,21 @@
     .volume-control input[type="range"]::-webkit-slider-thumb {
       -webkit-appearance: none;
       appearance: none;
-      width: 18px;
-      height: 18px;
+      width: 20px;
+      height: 20px;
       border-radius: 50%;
       background: var(--accent-4);
       cursor: pointer;
-      box-shadow: 0 4px 10px rgba(25, 130, 196, 0.35);
+      box-shadow: 0 6px 12px rgba(157, 107, 255, 0.4);
     }
 
     .volume-control input[type="range"]::-moz-range-thumb {
-      width: 18px;
-      height: 18px;
+      width: 20px;
+      height: 20px;
       border-radius: 50%;
       background: var(--accent-4);
       cursor: pointer;
-      box-shadow: 0 4px 10px rgba(25, 130, 196, 0.35);
+      box-shadow: 0 6px 12px rgba(157, 107, 255, 0.4);
       border: none;
     }
 
@@ -323,6 +379,7 @@
       font-weight: 600;
       font-size: 0.9rem;
       min-width: 3.25rem;
+      color: var(--text);
     }
 
     .stop {
@@ -330,16 +387,17 @@
     }
 
     .queue-panel {
-      margin-top: 2.5rem;
+      margin-top: 2.7rem;
       position: relative;
       z-index: 1;
-      background: rgba(255, 255, 255, 0.85);
-      border-radius: 18px;
-      padding: 1.4rem 1.6rem;
-      box-shadow: 0 12px 28px rgba(30, 30, 60, 0.16);
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 26px;
+      padding: 1.6rem 1.8rem;
+      box-shadow: 0 18px 36px rgba(48, 38, 59, 0.18);
       display: flex;
       flex-direction: column;
-      gap: 0.9rem;
+      gap: 1rem;
+      border: 2px solid rgba(157, 107, 255, 0.15);
     }
 
     .queue-panel__header {
@@ -351,19 +409,21 @@
 
     .queue-panel h2 {
       margin: 0;
-      font-size: 1.2rem;
+      font-size: 1.25rem;
+      color: var(--accent-4);
+      letter-spacing: 0.02em;
     }
 
     .queue-empty {
       margin: 0;
       font-size: 0.95rem;
-      color: rgba(29, 27, 47, 0.65);
+      color: var(--muted-text);
     }
 
     .queue-summary {
       margin: 0;
       font-size: 0.9rem;
-      color: rgba(29, 27, 47, 0.7);
+      color: rgba(48, 38, 59, 0.7);
       display: flex;
       gap: 0.4rem;
       align-items: baseline;
@@ -374,18 +434,19 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 0.2rem 0.65rem;
+      padding: 0.2rem 0.75rem;
       border-radius: 999px;
-      background: rgba(25, 130, 196, 0.12);
-      font-weight: 600;
-      letter-spacing: 0.04em;
+      background: rgba(123, 223, 242, 0.35);
+      font-weight: 700;
+      letter-spacing: 0.05em;
       text-transform: uppercase;
-      font-size: 0.7rem;
-      color: rgba(29, 27, 47, 0.75);
+      font-size: 0.72rem;
+      color: var(--text);
     }
 
     .queue-summary__text {
       font-weight: 600;
+      color: var(--text);
     }
 
     .queue-list {
@@ -402,93 +463,96 @@
       align-items: center;
       gap: 0.65rem;
       font-size: 0.95rem;
-      color: rgba(29, 27, 47, 0.9);
+      color: rgba(48, 38, 59, 0.9);
     }
 
     .queue-item .queue-pill {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      background: rgba(106, 76, 147, 0.14);
+      background: rgba(157, 107, 255, 0.16);
       color: var(--text);
       border-radius: 999px;
-      padding: 0.35rem 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.01em;
+      padding: 0.35rem 0.85rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
     }
 
     .queue-item .queue-meta {
       font-size: 0.8rem;
       text-transform: uppercase;
       letter-spacing: 0.08em;
-      color: rgba(29, 27, 47, 0.6);
+      color: rgba(48, 38, 59, 0.55);
     }
 
     .queue-item.queue-item--more {
       justify-content: flex-end;
       font-style: italic;
-      color: rgba(29, 27, 47, 0.6);
+      color: rgba(48, 38, 59, 0.55);
     }
 
     .queue-item.is-playing .queue-pill {
-      background: rgba(25, 130, 196, 0.16);
+      background: rgba(123, 223, 242, 0.45);
       color: var(--accent-4);
     }
 
     .queue-item.is-next .queue-pill {
-      background: rgba(255, 159, 28, 0.18);
-      color: var(--accent-1);
+      background: rgba(255, 169, 77, 0.45);
+      color: var(--accent-2);
     }
 
     button.clear-queue {
-      background: transparent;
-      border: 2px solid rgba(106, 76, 147, 0.3);
+      background: rgba(255, 255, 255, 0.8);
+      border: 2px solid rgba(157, 107, 255, 0.35);
       color: var(--text);
-      font-weight: 600;
+      font-weight: 700;
       border-radius: 999px;
-      padding: 0.45rem 1.1rem;
+      padding: 0.55rem 1.25rem;
       cursor: pointer;
-      transition: border-color 0.2s ease, transform 0.2s ease;
+      transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 8px 16px rgba(157, 107, 255, 0.18);
     }
 
     button.clear-queue:hover:not(:disabled) {
-      border-color: rgba(106, 76, 147, 0.65);
+      border-color: rgba(157, 107, 255, 0.6);
       transform: translateY(-2px);
+      box-shadow: 0 12px 20px rgba(157, 107, 255, 0.25);
     }
 
     button.clear-queue:disabled {
       cursor: not-allowed;
-      opacity: 0.6;
+      opacity: 0.55;
+      box-shadow: none;
     }
 
     button.stop {
-      background: var(--accent-4);
+      background: linear-gradient(120deg, var(--accent-1), var(--accent-4));
       color: #fff;
-      font-weight: 700;
+      font-weight: 800;
       font-size: 1.05rem;
       border: none;
       border-radius: 999px;
-      padding: 0.9rem 2.4rem;
+      padding: 0.95rem 2.6rem;
       cursor: pointer;
-      box-shadow: 0 14px 28px rgba(25, 130, 196, 0.35);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+      box-shadow: 0 18px 32px rgba(255, 138, 160, 0.35);
+      transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
     }
 
     button.stop:hover {
-      transform: translateY(-3px);
-      box-shadow: 0 18px 36px rgba(25, 130, 196, 0.35);
+      transform: translateY(-4px);
+      box-shadow: 0 22px 38px rgba(255, 138, 160, 0.4);
       filter: brightness(1.05);
     }
 
     button.stop:active {
-      transform: translateY(1px);
+      transform: translateY(0);
     }
 
     footer {
-      margin-top: 2rem;
+      margin-top: 2.2rem;
       text-align: center;
       font-size: 0.9rem;
-      color: rgba(29, 27, 47, 0.7);
+      color: rgba(48, 38, 59, 0.65);
       position: relative;
       z-index: 1;
     }
@@ -514,22 +578,22 @@
       display: flex;
       align-items: center;
       gap: 0.85rem;
-      background: rgba(255, 255, 255, 0.92);
-      border-radius: 22px;
-      padding: 0.75rem 1.1rem;
-      box-shadow: 0 18px 40px rgba(30, 30, 60, 0.2);
-      border: 2px solid rgba(106, 76, 147, 0.25);
-      backdrop-filter: blur(8px);
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 26px;
+      padding: 0.8rem 1.2rem;
+      box-shadow: 0 20px 44px rgba(157, 107, 255, 0.28);
+      border: 2px solid rgba(157, 107, 255, 0.3);
+      backdrop-filter: blur(10px);
     }
 
     .melody-toast__key {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-width: 48px;
-      min-height: 48px;
+      min-width: 50px;
+      min-height: 50px;
       padding: 0 0.75rem;
-      border-radius: 14px;
+      border-radius: 16px;
       background: var(--toast-accent);
       color: #fff;
       font-weight: 800;
@@ -537,6 +601,7 @@
       letter-spacing: 0.04em;
       white-space: nowrap;
       text-align: center;
+      box-shadow: inset 0 -4px 10px rgba(48, 38, 59, 0.18);
     }
 
     .melody-toast__text {
@@ -556,7 +621,7 @@
       font-size: 0.85rem;
       letter-spacing: 0.04em;
       text-transform: uppercase;
-      color: rgba(29, 27, 47, 0.65);
+      color: rgba(48, 38, 59, 0.55);
     }
 
     @media (max-width: 600px) {
@@ -565,30 +630,25 @@
       }
 
       .keys-grid {
-        gap: 1.1rem;
+        gap: 1.2rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       }
 
-      .keys-row {
-        grid-auto-columns: minmax(140px, 70%);
-      }
-
-      .key-card {
-        padding: 1.1rem 0.85rem 1.7rem;
+      .melody-card {
+        padding: 1.35rem 1.05rem 1.95rem;
       }
 
       .now-playing {
-        padding: 0.75rem 1rem;
+        padding: 0.8rem 1.05rem;
         font-size: 0.95rem;
       }
 
-      .key-card span.letter {
-        width: 60px;
-        height: 60px;
-        font-size: 2.2rem;
+      .melody-card .spot-icon {
+        font-size: 1.9rem;
       }
 
       .queue-panel {
-        padding: 1.1rem 1.2rem;
+        padding: 1.3rem 1.35rem;
       }
 
       .queue-panel__header {
@@ -610,8 +670,8 @@
       }
 
       .melody-toast__key {
-        min-width: 44px;
-        min-height: 44px;
+        min-width: 46px;
+        min-height: 46px;
         font-size: 1.2rem;
       }
     }
@@ -620,11 +680,11 @@
 <body>
   <main>
     <header>
-      <h1>Classical Melody Keyboard</h1>
-      <p class="lead">Every key on your keyboard lights up with a gentle classical riff—press one key or tap a card, then listen all the way through (or line up a few; they patiently wait their turn!).</p>
+      <h1>Keyboard Kids</h1>
+      <p class="lead">Pick a playful music spot, queue up a few favourites, and let each button burst into a kid-sized classical melody.</p>
       <div class="now-playing" role="status" aria-live="polite">
         <span class="label">Now playing</span>
-        <span class="value">Press any key or tap a card to begin!</span>
+        <span class="value">Tap a colorful music spot to start the concert!</span>
       </div>
     </header>
 
@@ -638,14 +698,14 @@
       </div>
     </div>
 
-    <section class="keys-grid" aria-label="Keyboard melody options"></section>
+    <section class="keys-grid" aria-label="Melody play spots"></section>
 
     <aside class="queue-panel" aria-label="Playback queue" aria-live="polite">
       <div class="queue-panel__header">
         <h2>Playback queue</h2>
         <button class="clear-queue" type="button" id="clearQueueButton" disabled>Clear queue</button>
       </div>
-      <p class="queue-empty" id="queueEmptyMessage">No melodies queued yet—tap a card or press a key to line one up.</p>
+      <p class="queue-empty" id="queueEmptyMessage">No melodies queued yet—tap a music spot to line one up.</p>
       <p class="queue-summary" id="queueSummary" hidden>
         <span class="queue-summary__pill" id="queueCount"></span>
         <span class="queue-summary__text" id="queueDuration"></span>
@@ -663,7 +723,7 @@
     </div>
 
     <footer>
-      Tip: Turn the volume to a comfy level, then explore the melodies together—line up as many keys as you like and they'll take turns.
+      Tip: Pair up and try patterns together—the queue keeps every melody waiting its turn with a smile.
     </footer>
   </main>
 
@@ -948,126 +1008,58 @@
       }
     };
 
-    const KEY_ROWS = [
-      ['Escape', '`', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', 'Backspace'],
-      ['Tab', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '[', ']', '\'],
-      ['CapsLock', 'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', ';', "'", 'Enter'],
-      ['Shift', 'z', 'x', 'c', 'v', 'b', 'n', 'm', ',', '.', '/'],
-      ['Control', 'Alt', 'Space', 'AltGraph', 'Meta'],
-      ['Insert', 'Home', 'PageUp', 'Delete', 'End', 'PageDown', 'ArrowLeft', 'ArrowDown', 'ArrowUp', 'ArrowRight']
-    ];
-
-    const COLOR_POOL = [
-      'var(--accent-1)',
-      'var(--accent-2)',
-      'var(--accent-3)',
-      'var(--accent-4)',
-      'var(--accent-5)',
-      'var(--accent-6)'
-    ];
-
-    const PATTERN_SEQUENCE = [
-      'ode',
-      'mozart',
-      'minuet',
-      'canon',
-      'sugarPlum',
-      'morning',
-      'twinkle',
-      'clair',
-      'swan',
-      'blueDanube',
-      'spring',
-      'gymno',
-      'lullaby'
-    ];
-
-    const FRIENDLY_NAMES = {
-      'Escape': 'Esc',
-      '`': 'Backtick',
-      '-': 'Minus',
-      '=': 'Equals',
-      'Backspace': 'Backspace',
-      'Tab': 'Tab',
-      '[': 'Left Bracket',
-      ']': 'Right Bracket',
-      '\': 'Backslash',
-      'CapsLock': 'Caps Lock',
-      ';': 'Semicolon',
-      "'": 'Apostrophe',
-      'Enter': 'Enter',
-      'Shift': 'Shift',
-      ',': 'Comma',
-      '.': 'Period',
-      '/': 'Slash',
-      'Control': 'Ctrl',
-      'Alt': 'Alt',
-      'Space': 'Space',
-      'AltGraph': 'AltGr',
-      'Meta': 'Meta',
-      'Insert': 'Insert',
-      'Home': 'Home',
-      'PageUp': 'Pg Up',
-      'Delete': 'Delete',
-      'End': 'End',
-      'PageDown': 'Pg Dn',
-      'ArrowLeft': '←',
-      'ArrowDown': '↓',
-      'ArrowUp': '↑',
-      'ArrowRight': '→'
-    };
-
-    function datasetKeyFor(key) {
-      switch (key) {
-        case 'Escape': return 'escape';
-        case ' ': return 'space';
-        case '`': return 'backtick';
-        case '-': return 'minus';
-        case '=': return 'equals';
-        case 'Backspace': return 'backspace';
-        case 'Tab': return 'tab';
-        case '[': return 'leftbracket';
-        case ']': return 'rightbracket';
-        case '\': return 'backslash';
-        case 'CapsLock': return 'capslock';
-        case ';': return 'semicolon';
-        case "'": return 'apostrophe';
-        case 'Enter': return 'enter';
-        case 'Shift': return 'shift';
-        case ',': return 'comma';
-        case '.': return 'period';
-        case '/': return 'slash';
-        case 'Control': return 'control';
-        case 'Alt': return 'alt';
-        case 'Space': return 'space';
-        case 'AltGraph': return 'altgraph';
-        case 'Meta': return 'meta';
-        case 'Insert': return 'insert';
-        case 'Home': return 'home';
-        case 'PageUp': return 'pageup';
-        case 'Delete': return 'delete';
-        case 'End': return 'end';
-        case 'PageDown': return 'pagedown';
-        case 'ArrowLeft': return 'arrowleft';
-        case 'ArrowDown': return 'arrowdown';
-        case 'ArrowUp': return 'arrowup';
-        case 'ArrowRight': return 'arrowright';
-        default: return key;
+    const PLAY_SPOTS = [
+      {
+        id: 'sunny-meadow',
+        name: 'Sunny Meadow',
+        description: "Bounce along with Beethoven's happiest tune.",
+        patternId: 'ode',
+        icon: '🌻',
+        color: 'var(--accent-5)'
+      },
+      {
+        id: 'starlight-stage',
+        name: 'Starlight Stage',
+        description: 'Mozart sprinkles twinkly notes across the sky.',
+        patternId: 'mozart',
+        icon: '🌟',
+        color: 'var(--accent-4)'
+      },
+      {
+        id: 'moonlit-lagoon',
+        name: 'Moonlit Lagoon',
+        description: 'Dreamy ripples from Debussy shimmer on the water.',
+        patternId: 'clair',
+        icon: '🌙',
+        color: 'var(--accent-3)'
+      },
+      {
+        id: 'swan-pond',
+        name: 'Swan Pond',
+        description: 'Glide with Tchaikovsky through gentle waltz waves.',
+        patternId: 'swan',
+        icon: '🦢',
+        color: 'var(--accent-6)'
+      },
+      {
+        id: 'spring-garden',
+        name: 'Spring Garden',
+        description: "Vivaldi's violins bloom in a swirl of petals.",
+        patternId: 'spring',
+        icon: '🌼',
+        color: 'var(--accent-2)'
+      },
+      {
+        id: 'dreamy-nook',
+        name: 'Dreamy Nook',
+        description: 'Snuggle in for Brahms’ gentle lullaby.',
+        patternId: 'lullaby',
+        icon: '💤',
+        color: 'var(--accent-7)'
       }
-    }
-
-    function displayLabelFor(key) {
-      if (key === ' ') {
-        return 'Space';
-      }
-      if (FRIENDLY_NAMES[key]) {
-        return FRIENDLY_NAMES[key];
-      }
-      return key.length === 1 ? key.toUpperCase() : key;
-    }
+    ];
 
     const melodies = {};
-    const keyMatcher = {};
     const keysGrid = document.querySelector('.keys-grid');
     const nowPlayingValue = document.querySelector('.now-playing .value');
     const queueList = document.querySelector('.queue-list');
@@ -1084,133 +1076,61 @@
     const volumeValue = document.getElementById('volumeValue');
     const stopButton = document.getElementById('stopButton');
     const STORAGE_KEYS = {
-      volume: 'classicalKeyboard.volumeLevel'
+      volume: 'keyboardKids.volumeLevel'
     };
 
-    const KEY_ROW_LABELS = [
-      'Esc & numbers',
-      'Top letters',
-      'Home row',
-      'Bottom row',
-      'Space & modifiers',
-      'Navigation keys'
-    ];
-
-    const rowContainers = [];
     if (keysGrid) {
-      KEY_ROWS.forEach((_, rowIndex) => {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'keys-row-wrapper';
+      PLAY_SPOTS.forEach((spot, index) => {
+        const pattern = PATTERN_LIBRARY[spot.patternId];
+        if (!pattern) {
+          return;
+        }
 
-        const labelId = `keys-row-label-${rowIndex + 1}`;
-        const label = document.createElement('div');
-        label.className = 'keys-row-label';
-        label.id = labelId;
-        label.textContent = KEY_ROW_LABELS[rowIndex] || `Row ${rowIndex + 1}`;
-        wrapper.appendChild(label);
+        const fallbackAccentIndex = (index % 6) + 1;
+        const color = spot.color || `var(--accent-${fallbackAccentIndex})`;
+        const icon = spot.icon || '🎵';
 
-        const rowElement = document.createElement('div');
-        rowElement.className = 'keys-row';
-        rowElement.setAttribute('role', 'group');
-        rowElement.setAttribute('aria-labelledby', labelId);
-        wrapper.appendChild(rowElement);
+        melodies[spot.id] = {
+          title: pattern.title,
+          composer: pattern.composer,
+          keyLabel: spot.name,
+          notes: pattern.notes
+        };
 
-        keysGrid.appendChild(wrapper);
-        rowContainers.push(rowElement);
+        const card = document.createElement('article');
+        card.className = 'melody-card';
+        card.dataset.key = spot.id;
+        card.dataset.color = color;
+        card.style.setProperty('--card-color', color);
+        card.innerHTML = `
+          <span class="spot-icon" aria-hidden="true">${icon}</span>
+          <h3 class="spot-name">${spot.name}</h3>
+          <p class="melody-title">${pattern.title}</p>
+          <p class="melody-composer">${pattern.composer}</p>
+          ${spot.description ? `<p class="spot-description">${spot.description}</p>` : ''}
+          <div class="progress-track" aria-hidden="true">
+            <div class="progress-bar"></div>
+          </div>
+        `;
+        card.setAttribute('title', `${spot.name} plays ${pattern.title}`);
+        card.setAttribute('aria-label', `${spot.name} plays ${pattern.title}`);
+        card.setAttribute('role', 'button');
+        card.setAttribute('tabindex', '0');
+
+        const activate = () => enqueueMelody(spot.id);
+
+        card.addEventListener('click', activate);
+        card.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            event.stopPropagation();
+            activate();
+          }
+        });
+
+        keysGrid.appendChild(card);
       });
     }
-
-    const keyEntries = [];
-    KEY_ROWS.forEach((row, rowIndex) => {
-      row.forEach((key) => {
-        const datasetKey = datasetKeyFor(key);
-        const display = displayLabelFor(key);
-        keyEntries.push({ key, datasetKey, display, rowIndex });
-      });
-    });
-
-    keyEntries.forEach((entry, index) => {
-      const patternId = PATTERN_SEQUENCE[index % PATTERN_SEQUENCE.length];
-      const pattern = PATTERN_LIBRARY[patternId];
-      const color = COLOR_POOL[index % COLOR_POOL.length];
-
-      melodies[entry.datasetKey] = {
-        title: pattern.title,
-        composer: pattern.composer,
-        keyLabel: entry.display,
-        notes: pattern.notes
-      };
-
-      const card = document.createElement('article');
-      card.className = 'key-card';
-      card.dataset.key = entry.datasetKey;
-      card.dataset.color = color;
-      card.style.setProperty('--card-color', color);
-      card.innerHTML = `
-        <span class="letter" aria-hidden="true">${entry.display}</span>
-        <span class="title">${pattern.title}</span>
-        <span class="subtitle">${pattern.composer}</span>
-        <div class="progress-track" aria-hidden="true">
-          <div class="progress-bar"></div>
-        </div>
-      `;
-      card.setAttribute('title', `${entry.display} key · ${pattern.title}`);
-      card.setAttribute('aria-label', `${entry.display} key plays ${pattern.title}`);
-      card.setAttribute('role', 'button');
-      card.setAttribute('tabindex', '0');
-      const host = rowContainers[entry.rowIndex] || keysGrid;
-      if (host) {
-        host.appendChild(card);
-      }
-
-      const letterSpan = card.querySelector('.letter');
-      if (entry.display.length > 2) {
-        letterSpan.style.fontSize = 'clamp(1.1rem, 2.4vw, 1.5rem)';
-        letterSpan.style.padding = '0 0.45rem';
-        letterSpan.style.letterSpacing = '0.02em';
-      }
-      if (entry.display.length > 7) {
-        letterSpan.style.fontSize = 'clamp(0.95rem, 2vw, 1.2rem)';
-      }
-
-      const gradient = `linear-gradient(145deg, ${color}33, #ffffff)`;
-      letterSpan.style.background = color;
-      card.style.background = gradient;
-
-      const activate = () => enqueueMelody(entry.datasetKey);
-
-      card.addEventListener('click', activate);
-      card.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          event.stopPropagation();
-          activate();
-        }
-      });
-
-      keyMatcher[entry.key] = entry.datasetKey;
-      keyMatcher[entry.key.toLowerCase()] = entry.datasetKey;
-      if (entry.key.length === 1) {
-        keyMatcher[entry.key.toUpperCase()] = entry.datasetKey;
-      }
-      if (entry.key === ' ' || entry.key === 'Space') {
-        keyMatcher[' '] = entry.datasetKey;
-        keyMatcher['Spacebar'] = entry.datasetKey;
-      }
-      if (entry.key === 'Escape') {
-        keyMatcher['Esc'] = entry.datasetKey;
-      }
-      if (entry.key === 'Enter') {
-        keyMatcher['Return'] = entry.datasetKey;
-      }
-      if (entry.key === 'Meta') {
-        keyMatcher['OS'] = entry.datasetKey;
-        keyMatcher['Win'] = entry.datasetKey;
-      }
-      if (entry.key === 'AltGraph') {
-        keyMatcher['AltGr'] = entry.datasetKey;
-      }
-    });
 
     const audioContext = new (window.AudioContext || window.webkitAudioContext)();
     const masterGain = audioContext.createGain();
@@ -1250,8 +1170,7 @@
 
       if (melodyToastKey) {
         const label = melody.keyLabel || key;
-        const normalized = label.length === 1 ? label.toUpperCase() : label;
-        const trimmed = normalized.length > 10 ? `${normalized.slice(0, 9)}…` : normalized;
+        const trimmed = label.length > 18 ? `${label.slice(0, 17)}…` : label;
         melodyToastKey.textContent = trimmed;
       }
 
@@ -1269,7 +1188,7 @@
         }
       }
 
-      const card = document.querySelector(`.key-card[data-key="${key}"]`);
+      const card = document.querySelector(`.melody-card[data-key="${key}"]`);
       if (card && card.dataset && card.dataset.color) {
         const accent = card.dataset.color;
         melodyToast.style.setProperty('--toast-accent', accent);
@@ -1496,7 +1415,7 @@
       if (!melody) {
         return null;
       }
-      return `${melody.title} — ${melody.composer} (${melody.keyLabel} key)`;
+      return `${melody.title} — ${melody.composer} (${melody.keyLabel})`;
     }
 
     function refreshNowPlayingStatus() {
@@ -1517,7 +1436,7 @@
           return;
         }
       }
-      nowPlayingValue.textContent = 'Press any key or tap a card to begin!';
+      nowPlayingValue.textContent = 'Tap a music spot to begin!';
     }
 
     function wait(ms) {
@@ -1525,7 +1444,7 @@
     }
 
     function updateQueueIndicators() {
-      const cards = document.querySelectorAll('.key-card');
+      const cards = document.querySelectorAll('.melody-card');
       const queuedSet = new Set(playbackQueue);
       const currentKey = currentCard ? currentCard.dataset.key : null;
       cards.forEach((card) => {
@@ -1541,7 +1460,7 @@
 
     function setActiveCard(key, totalDuration) {
       unsetActiveCard();
-      const card = document.querySelector(`.key-card[data-key="${key}"]`);
+      const card = document.querySelector(`.melody-card[data-key="${key}"]`);
       if (card) {
         currentCard = card;
         currentDurationEstimate = typeof totalDuration === 'number' ? totalDuration : 0;
@@ -1743,17 +1662,6 @@
       hideMelodyToast(true);
     }
 
-    document.addEventListener('keydown', (event) => {
-      const rawKey = event.key;
-      const lowerKey = typeof rawKey === 'string' ? rawKey.toLowerCase() : rawKey;
-      const upperKey = typeof rawKey === 'string' ? rawKey.toUpperCase() : rawKey;
-      const datasetKey = keyMatcher[rawKey] || keyMatcher[lowerKey] || keyMatcher[upperKey];
-      if (datasetKey) {
-        event.preventDefault();
-        enqueueMelody(datasetKey);
-      }
-    });
-
     if (stopButton) {
       stopButton.addEventListener('click', () => {
         stopPlayback();
@@ -1802,7 +1710,7 @@
     }
 
     setTimeout(() => {
-      const cards = document.querySelectorAll('.key-card');
+      const cards = document.querySelectorAll('.melody-card');
       cards.forEach((card, index) => {
         setTimeout(() => {
           card.dataset.active = 'true';


### PR DESCRIPTION
## Summary
- replace the keyboard grid with six themed melody play spots that queue classical tunes when tapped
- refresh styling and copy to support the new card-based layout and toast messaging for kids

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8974800dc832f8b56d36c110144b4